### PR TITLE
Cargo update 2026 06 30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nat-detect"
-version = "0.1.7"
+version = "0.1.9"
 edition = "2021"
 authors = ["blazh <blazh@163.com>"]
 keywords = ["nat", "stun", "detect"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository = "https://github.com/blazood/nat-detect"
 
 [dependencies]
 tokio = { version = "1.17", features = ["full"] }
-stun_codec_blazh= {version="0.1.13"}
+stun_codec_blazh= { version="0.1.13" }
 log = "0.4"
-simple_logger = "2.1"
-clap = { version = "3.1", features = ["derive"] }
-rand = "0.8.5"
+simple_logger = "5.2"
+clap = { version = "4.5.60", features = ["derive"] }
+rand = "0.10.0"
 bytecodec = "0.4.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ stun_codec_blazh= { version="0.1.13" }
 log = "0.4"
 simple_logger = "5.2"
 clap = { version = "4.5.60", features = ["derive"] }
-rand = "0.10.0"
+rand = "0.10.1"
 bytecodec = "0.4.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/blazood/nat-detect"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.17", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 stun_codec_blazh= { version="0.1.13" }
 log = "0.4"
 simple_logger = "5.2"
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 rand = "0.10.1"
 bytecodec = "0.4.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,19 +2,19 @@ use simple_logger::SimpleLogger;
 use nat_detect::nat_detect_with_servers;
 use clap::Parser;
 use log::LevelFilter;
-use rand::Rng;
+use rand::RngExt;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Args {
 
-    #[clap(short, long,help="default use https://github.com/pradt2/always-online-stun")]
+    #[arg(short, long, help = "default use https://github.com/pradt2/always-online-stun")]
     stun_servers: Option<Vec<String>>,
 
-    #[clap(short='c', long, default_value="20")]
+    #[arg(short = 'c', long, default_value = "20")]
     stun_servers_count: usize,
 
-    #[clap(short='v', long="verbose")]
+    #[arg(short = 'v', long = "verbose")]
     verbose: bool,
 
 }
@@ -32,10 +32,10 @@ pub async fn main(){
     let vec = args.stun_servers.unwrap_or_else(|| {
         let vec: Vec<String> = include_str!("valid_ipv4s.txt").lines().map(|e|e.trim().to_string()).collect();
         // select 10 server randomly
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut new_vec = Vec::new();
         for _ in 0..args.stun_servers_count {
-            let stun_server = vec[rng.gen_range(0..vec.len())].to_string();
+            let stun_server = vec[rng.random_range(0..vec.len())].to_string();
             new_vec.push(stun_server);
         }
         new_vec


### PR DESCRIPTION
Description:
Problem: Dependencies are outdated

Solution - Direct dependency bumps:
- `tokio`: 1.17 -> 1.52
- `clap`: 4.5.60 -> 4.6.1

Failed bumps:
- `bytecodec`: 0.4.15 -> 0.5.0 (blocked because v0.4.15 is required by the `stun_codec_blazh` 0.1.13 dependency)